### PR TITLE
Suppress overflow warning in _LoadData.py

### DIFF
--- a/GHEtool/VariableClasses/LoadData/Baseclasses/_LoadData.py
+++ b/GHEtool/VariableClasses/LoadData/Baseclasses/_LoadData.py
@@ -447,10 +447,9 @@ class _LoadData(ABC, BaseClass):
         -------
         Times for the L4 sizing : np.ndarray
         """
-        # set the time constant for the L4 sizing while surpressing overflow warning
+        # set the time constant for the L4 sizing while suppressing overflow warning
         with np.errstate(over='ignore'):
             time_L4 = 3600 * np.arange(1, 8760 * self.simulation_period + 1, dtype=np.float16)
-        time_L4 = 3600 * np.arange(1, 8760 * self.simulation_period + 1, dtype=np.float16)
         if np.isinf(time_L4).any():
             # 16 bit is not enough, go to 32
             time_L4 = 3600 * np.arange(1, 8760 * self.simulation_period + 1, dtype=np.float32)


### PR DESCRIPTION
While working with hourly building load data, I repeatedly encountered a `RuntimeWarning` about an overflow in `float16` which worried me. After looking into the code, I saw that the warning is harmless/not necessary: if an overflow occurs, the array is automatically recreated using `float32` in the next lines. To avoid confusion, I suggest to suppress the warning.