### PR TITLE
Fix problem with slow conical probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Fixed
 
 - Fixed problem when calculating temperature of boreholes with different depth.
+- Fix problem with slow Rf calculation conical probe.
 - Fixed minor mistake in Separatus Rb* calculation (issue #425).
 - Missing method attribute in gt.gfunction.gFunction call (issue #428, thanks to @Wouterr0).
 - Problem with convergence when working with variable fluid properties (issue #435).

--- a/GHEtool/VariableClasses/PipeData/ConicalPipe.py
+++ b/GHEtool/VariableClasses/PipeData/ConicalPipe.py
@@ -182,7 +182,7 @@ class ConicalPipe(MultipleUTube):
             # Contribution after conical section
             R3 = 0.0
             if L3 > 0:
-                rf_stop = r_f_func(self.end_conical)
+                rf_stop = r_f_func(borehole_length)
                 R3 = rf_stop * L3
 
             result = (R1 + R2 + R3) / borehole_length

--- a/GHEtool/VariableClasses/PipeData/ConicalPipe.py
+++ b/GHEtool/VariableClasses/PipeData/ConicalPipe.py
@@ -169,44 +169,20 @@ class ConicalPipe(MultipleUTube):
             # Contribution before conical section
             R1 = 0.0
             if L1 > 0:
-                rf_start = calculate_convective_resistance(
-                    flow_data,
-                    fluid_data,
-                    r_in=self.r_in_start,
-                    epsilon=self.epsilon,
-                    nb_of_pipes=self.number_of_pipes,
-                    **kwargs
-                )
+                rf_start = r_f_func(0)
                 R1 = rf_start * L1
 
             # Contribution in conical section
             R2 = 0.0
             if L2 > 0:
                 z_cone = np.linspace(self.begin_conical, min(self.end_conical, borehole_length), 9)
-                rf_cone = np.array([
-                    calculate_convective_resistance(
-                        flow_data,
-                        fluid_data,
-                        r_in=calc_r_in(z),
-                        epsilon=self.epsilon,
-                        nb_of_pipes=self.number_of_pipes,
-                        **kwargs
-                    )
-                    for z in z_cone
-                ])
+                rf_cone = np.array([r_f_func(z) for z in z_cone])
                 R2 = scipy.integrate.simpson(rf_cone, x=z_cone, axis=0)
 
             # Contribution after conical section
             R3 = 0.0
             if L3 > 0:
-                rf_stop = calculate_convective_resistance(
-                    flow_data,
-                    fluid_data,
-                    r_in=self.r_in_stop,
-                    epsilon=self.epsilon,
-                    nb_of_pipes=self.number_of_pipes,
-                    **kwargs
-                )
+                rf_stop = r_f_func(self.end_conical)
                 R3 = rf_stop * L3
 
             result = (R1 + R2 + R3) / borehole_length

--- a/GHEtool/VariableClasses/PipeData/ConicalPipe.py
+++ b/GHEtool/VariableClasses/PipeData/ConicalPipe.py
@@ -4,6 +4,8 @@ import math
 
 from math import pi
 
+import scipy
+
 from GHEtool.utils.calculate_friction_factor import *
 from GHEtool.VariableClasses.PipeData.SingleUTube import MultipleUTube
 from GHEtool.VariableClasses.FluidData import _FluidData
@@ -159,7 +161,56 @@ class ConicalPipe(MultipleUTube):
                 return calculate_convective_resistance(flow_data, fluid_data, r_in=calc_r_in(length),
                                                        epsilon=self.epsilon, nb_of_pipes=self.number_of_pipes, **kwargs)
 
-            return quad_vec(r_f_func, 0, borehole_length)[0] / borehole_length
+            # Lengths of the three regions
+            L1 = max(0.0, min(self.begin_conical, borehole_length))
+            L2 = max(0.0, min(self.end_conical, borehole_length) - self.begin_conical)
+            L3 = max(0.0, borehole_length - max(self.end_conical, 0.0))
+
+            # Contribution before conical section
+            R1 = 0.0
+            if L1 > 0:
+                rf_start = calculate_convective_resistance(
+                    flow_data,
+                    fluid_data,
+                    r_in=self.r_in_start,
+                    epsilon=self.epsilon,
+                    nb_of_pipes=self.number_of_pipes,
+                    **kwargs
+                )
+                R1 = rf_start * L1
+
+            # Contribution in conical section
+            R2 = 0.0
+            if L2 > 0:
+                z_cone = np.linspace(self.begin_conical, min(self.end_conical, borehole_length), 9)
+                rf_cone = np.array([
+                    calculate_convective_resistance(
+                        flow_data,
+                        fluid_data,
+                        r_in=calc_r_in(z),
+                        epsilon=self.epsilon,
+                        nb_of_pipes=self.number_of_pipes,
+                        **kwargs
+                    )
+                    for z in z_cone
+                ])
+                R2 = scipy.integrate.simpson(rf_cone, x=z_cone, axis=0)
+
+            # Contribution after conical section
+            R3 = 0.0
+            if L3 > 0:
+                rf_stop = calculate_convective_resistance(
+                    flow_data,
+                    fluid_data,
+                    r_in=self.r_in_stop,
+                    epsilon=self.epsilon,
+                    nb_of_pipes=self.number_of_pipes,
+                    **kwargs
+                )
+                R3 = rf_stop * L3
+
+            result = (R1 + R2 + R3) / borehole_length
+            return result
 
         R_f_top = calculate_convective_resistance(flow_data, fluid_data, r_in=self.r_in_start, epsilon=self.epsilon,
                                                   nb_of_pipes=self.number_of_pipes, **kwargs)

--- a/GHEtool/test/unit-tests/test_pipedata.py
+++ b/GHEtool/test/unit-tests/test_pipedata.py
@@ -601,7 +601,7 @@ def test_conical_resistances():
 
     pipe.calculate_resistances(fluid, flow, 200)
     assert np.isclose(0.07358834823796871, pipe.R_p)
-    assert np.isclose(0.17880743362651824, pipe.R_f)
+    assert np.isclose(0.1787639520941072, pipe.R_f)
 
 
 def test_conical_convective_resistance():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = GHEtool
-version = 2.4.1.dev6
+version = 2.4.1.dev7
 author = Wouter Peere
 author_email = wouter@ghetool.eu
 description = Python package for borefield sizing


### PR DESCRIPTION
Improvement in the Rf calculation of the conical probes, which is slow for hourly data.
The solution is to work with simpsons rule for integration (instead of quad_vec) and to only apply it to the connical section. The straight parts can be computed directly. Afterwards, the results get weighted for the same result.

Time is easily 1000x faster and accuracy within <1e-5