### PR TITLE
Evaluate the cylindrical correction once per group and memoise the CHS solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Evaluate the cylindrical correction once per borehole group and cache the CHS solution.
 - Move calculate_borefield_inlet_outlet_temperature to Borehole class (issue #464).
 - Change implementation ConicalProbe for speed improvement (issue #472).
 - Change implementation of interpolation for _Efficiency class to cope with non-gridded data input (issue #472).

--- a/GHEtool/VariableClasses/Cylindrical_correction.py
+++ b/GHEtool/VariableClasses/Cylindrical_correction.py
@@ -19,6 +19,13 @@ from scipy.interpolate import interp1d as interp1d
 from time import perf_counter
 
 
+# The CHS solution depends only on (time, alpha, r, r_b). During an iterative sizing
+# the borehole length changes but these do not, so it is requested repeatedly with
+# identical arguments. The results are memoised on those arguments.
+_CHS_CACHE: dict = {}
+_CHS_CACHE_MAX_SIZE: int = 32
+
+
 # update pygfunction
 def cylindrical_heat_source(
         time, alpha, r, r_b):
@@ -68,6 +75,12 @@ def cylindrical_heat_source(
     CHS_integrand = lambda u: (1. / (u ** 2 * np.pi ** 2) * (np.exp(-u ** 2 * Fo) - 1.0)
                                / (j1(u) ** 2 + y1(u) ** 2) * (j0(p * u) * y1(u) - j1(u) * y0(p * u)))
 
+    time_arr = np.asarray(time, dtype=np.float64)
+    key = (float(alpha), float(r), float(r_b), time_arr.shape, time_arr.tobytes())
+    cached = _CHS_CACHE.get(key)
+    if cached is not None:
+        return cached.copy() if isinstance(cached, np.ndarray) else cached
+
     # Fourier number
     Fo = alpha * time / r_b ** 2
     # Normalized distance from borehole axis
@@ -78,6 +91,10 @@ def cylindrical_heat_source(
     b = np.inf
     # Evaluate integral using Gauss-Kronrod
     G = quad_vec(CHS_integrand, a, b)[0]
+
+    if len(_CHS_CACHE) >= _CHS_CACHE_MAX_SIZE:
+        _CHS_CACHE.clear()
+    _CHS_CACHE[key] = G.copy() if isinstance(G, np.ndarray) else G
     return G
 
 
@@ -210,6 +227,15 @@ def thermal_response_factors(self, time, alpha, kind='linear'):
         h = finite_line_source_vectorized(
             time, alpha, dis, H1, D1, H2, D2,
             approximation=self.approximate_FLS, N=self.nFLS)
+        # The cylindrical correction depends only on the borehole dimensions, and the
+        # groups of borehole_to_self correspond to unique borehole dimensions (the
+        # representative group[0] is already used for H1, D1, H2, D2 and dis above).
+        # It is therefore evaluated once per group instead of once per borehole.
+        if self.cylindrical_correction:
+            r_b = self.boreholes[i].r_b
+            h_ils = infinite_line_source(time, alpha, dis)
+            h_chs = cylindrical_heat_source(time, alpha, r_b, r_b)
+            correction = 2 * np.pi * h_chs - 0.5 * h_ils
         # Broadcast values to h_ij matrix
         for i in group:
             i_segment = self._i0Segments[i] + i_pair
@@ -218,12 +244,9 @@ def thermal_response_factors(self, time, alpha, kind='linear'):
                 h_ij[j_segment, i_segment, 1:] + h[0, k_pair, :]
 
             if self.cylindrical_correction:
-                r_b = self.boreholes[i].r_b
                 ii_segment = j_segment[j_segment == i_segment]
-                h_ils = infinite_line_source(time, alpha, dis)
-                h_chs = cylindrical_heat_source(time, alpha, r_b, r_b)
                 h_ij[ii_segment, ii_segment, 1:] = (
-                        h_ij[ii_segment, ii_segment, 1:] + 2 * np.pi * h_chs - 0.5 * h_ils)
+                        h_ij[ii_segment, ii_segment, 1:] + correction)
 
     # Return 2d array if time is a scalar
     if np.isscalar(time):


### PR DESCRIPTION
## What this does

Two changes to the finite-radius cylindrical correction, both leaving the computed quantity unchanged.

**1. Evaluate the correction once per group.** The correction added to a borehole's self-response,

    2 pi G_CHS(t, alpha, r_b, r_b) - 0.5 G_ILS(t, alpha, dis)

depends only on the borehole dimensions. The groups of `borehole_to_self` correspond to unique borehole dimensions
(the file's own comment says so), and the representative `group[0]` is already used to evaluate `H1, D1, H2, D2` and
`dis` for the whole group just above. The correction was nevertheless recomputed inside the per-borehole broadcast
loop, so a group of n identical boreholes paid for n identical CHS and ILS quadratures.

**2. Memoise the CHS solution.** The Carslaw and Jaeger cylindrical heat source solution [#CarslawJaeger1946] is
evaluated by quadrature and depends only on `(time, alpha, r, r_b)`. During an iterative sizing the borehole length
varies but none of those do, so every iteration re-evaluates the same integral.

## Correctness

Against `upstream/main`, 5x4 field, H = 110 m, 40 log-spaced times over 20 years:

| | difference |
|---|---|
| `cylindrical_correction=False` | **bit-identical** |
| `cylindrical_correction=True` | max relative **3.2e-15** |

The residual is purely the re-association of the correction sum, from `((h + 2 pi G_CHS) - 0.5 G_ILS)` to
`(h + (2 pi G_CHS - 0.5 G_ILS))`. No quantity in the calculation changed.

## Measured

Repeated corrected g-function evaluation mimicking a sizing loop (10x10 field, 50 log-spaced times, five borehole
lengths at fixed `time, alpha, r_b`), best and median of 7:

| | best | median |
|---|---|---|
| `upstream/main` | 0.7294 s | 0.7566 s |
| this branch | 0.6739 s | 0.6824 s |
| | **-8%** | **-10%** |

Consistent in direction and magnitude across two independent runs.

## A design question for you

The CHS memo is a module-level dict keyed on `(alpha, r, r_b, shape, time.tobytes())` with a clear-at-32 eviction.
That is deliberate but crude, and it is the part of this PR I would most expect you to have an opinion on. If you
would rather not carry module-level state, I am happy to drop the memo and keep only the per-group hoist, which
carries most of the physics argument and none of the state.

## Tests

Full unit-test suite: **509 passed**, identical to `upstream/main`.

---

### AI usage disclosure

This contribution was prepared with AI assistance (Claude, via Claude Code). The implementation, the tests and this
description were drafted with the model and then reviewed, run and validated by me; I am responsible for what is
proposed here. Every number quoted above was produced by running the code locally against stock `pygfunction 2.3.1`
from PyPI (not the author's fork, and not generated by the model). Commits carry a `Co-Authored-By: Claude` trailer.
