### PR TITLE
Cache the convolution kernel FFT in the hourly temperature calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Cache the FFT of the convolution kernel in the hourly temperature calculation.
 - Move calculate_borefield_inlet_outlet_temperature to Borehole class (issue #464).
 - Change implementation ConicalProbe for speed improvement (issue #472).
 - Change implementation of interpolation for _Efficiency class to cope with non-gridded data input (issue #472).

--- a/GHEtool/Borefield.py
+++ b/GHEtool/Borefield.py
@@ -14,7 +14,8 @@ import numpy as np
 import pygfunction as gt
 
 from numpy.typing import ArrayLike
-from scipy.signal import convolve
+from scipy.signal import choose_conv_method, convolve
+from scipy import fft as sp_fft
 
 from GHEtool.VariableClasses import FluidData, Borehole, GroundConstantTemperature, ResultsMonthly, ResultsHourly, \
     TemperatureDependentFluidData, SCOP, SEER
@@ -126,6 +127,46 @@ class Borefield(BaseClass):
 
         # temporary results
         self._temp_results = {}
+
+        # cache with the FFT of the convolution kernel (the g-value differences),
+        # which is reused over the iterations of the temperature calculation
+        self._kernel_fft_cache = {}
+
+    def _convolve_with_kernel(self, signal: np.ndarray, kernel: np.ndarray) -> np.ndarray:
+        """
+        This function convolves ('full' mode) the signal with the kernel, like
+        scipy.signal.convolve does, but it caches the FFT of the kernel. During the
+        iterative temperature calculations, the same kernel (the g-value differences)
+        is convolved over and over, so reusing its FFT saves time. The result is
+        identical to scipy.signal.convolve.
+
+        Parameters
+        ----------
+        signal : np.ndarray
+            1D array with the load values [W]
+        kernel : np.ndarray
+            1D array with the g-value differences
+
+        Returns
+        -------
+        result : np.ndarray
+            The full convolution of signal and kernel
+        """
+        if len(signal) == 0 or len(kernel) == 0 or signal.ndim != 1 or kernel.ndim != 1 \
+                or choose_conv_method(signal, kernel) != 'fft':
+            return convolve(signal, kernel)
+
+        # same shape logic as scipy.signal.fftconvolve for 1D real inputs
+        shape = len(signal) + len(kernel) - 1
+        fshape = sp_fft.next_fast_len(shape, True)
+        entry = self._kernel_fft_cache.get(fshape)
+        if entry is None or entry[0] is not kernel:
+            if len(self._kernel_fft_cache) >= 8:
+                self._kernel_fft_cache.clear()
+            entry = (kernel, sp_fft.rfft(kernel, fshape))
+            self._kernel_fft_cache[fshape] = entry
+        sp1 = sp_fft.rfft(signal, fshape)
+        return sp_fft.irfft(sp1 * entry[1], fshape)[:shape].copy()
 
     @property
     def number_of_boreholes(self) -> int:
@@ -1914,6 +1955,8 @@ class Borefield(BaseClass):
             # set Rb* value
             H_var = H if H is not None else self.H
             depth = self.calculate_depth(H_var, self.D)
+            # hoisted, since for multiyear loads every access recomputes the load arrays
+            load_simulation_period = self.load.simulation_period
 
             results = None
 
@@ -1926,7 +1969,7 @@ class Borefield(BaseClass):
                                                         depth,
                                                         temperature=Tmin, nb_of_boreholes=self.number_of_boreholes,
                                                         use_explicit_models=self._calculation_setup.use_explicit_multipole,
-                                                        simulation_period=self.load.simulation_period,
+                                                        simulation_period=load_simulation_period,
                                                         power=power,
                                                         temperature_borehole_wall=temperature_borehole_wall)
                         elif limit == (Tmax if Tmax is not None else self.Tf_max):
@@ -1935,7 +1978,7 @@ class Borefield(BaseClass):
                                                         temperature=max(temperature),
                                                         nb_of_boreholes=self.number_of_boreholes,
                                                         use_explicit_models=self._calculation_setup.use_explicit_multipole,
-                                                        simulation_period=self.load.simulation_period,
+                                                        simulation_period=load_simulation_period,
                                                         power=power,
                                                         temperature_borehole_wall=temperature_borehole_wall)
                         else:
@@ -1944,20 +1987,20 @@ class Borefield(BaseClass):
                                                         temperature=min(temperature),
                                                         nb_of_boreholes=self.number_of_boreholes,
                                                         use_explicit_models=self._calculation_setup.use_explicit_multipole,
-                                                        simulation_period=self.load.simulation_period,
+                                                        simulation_period=load_simulation_period,
                                                         power=power,
                                                         temperature_borehole_wall=temperature_borehole_wall)
                 if len(temperature) == 0:
                     return self.borehole.get_Rb(H_var, self.D, self.r_b, self.ground_data.k_s(depth, self.D), depth,
                                                 temperature=Tmin, nb_of_boreholes=self.number_of_boreholes,
                                                 use_explicit_models=self._calculation_setup.use_explicit_multipole,
-                                                simulation_period=self.load.simulation_period,
+                                                simulation_period=load_simulation_period,
                                                 power=power, temperature_borehole_wall=temperature_borehole_wall)
 
                 return self.borehole.get_Rb(H_var, self.D, self.r_b, self.ground_data.k_s(depth, self.D), depth,
                                             temperature=temperature, nb_of_boreholes=self.number_of_boreholes,
                                             use_explicit_models=self._calculation_setup.use_explicit_multipole,
-                                            simulation_period=self.load.simulation_period,
+                                            simulation_period=load_simulation_period,
                                             power=power, temperature_borehole_wall=temperature_borehole_wall)
 
             if not hourly:
@@ -1966,8 +2009,16 @@ class Borefield(BaseClass):
                     raise ValueError(
                         'No monthly temperature profile can be calculated when an hourly flow rate is given.')
 
+                # the load properties are hoisted into local variables, since every
+                # access recomputes them (which is expensive for building loads)
+                monthly_average_injection_power = self.load.monthly_average_injection_power_simulation_period
+                monthly_peak_injection = self.load.monthly_peak_injection_simulation_period
+                monthly_peak_extraction = self.load.monthly_peak_extraction_simulation_period
+                monthly_baseload_injection_power = self.load.monthly_baseload_injection_power_simulation_period
+                monthly_baseload_extraction_power = self.load.monthly_baseload_extraction_power_simulation_period
+
                 # convolution to get the monthly results
-                result_convolution = convolve(self.load.monthly_average_injection_power_simulation_period * 1000,
+                result_convolution = convolve(monthly_average_injection_power * 1000,
                                               g_value_differences)[: 12 * self.simulation_period]
 
                 # calculation the borehole wall temperature for every month i
@@ -1977,47 +2028,47 @@ class Borefield(BaseClass):
 
                 # now the Tf will be calculated based on
                 # Tf = Tb + Q * R_b
-                power = np.where(self.load.monthly_average_injection_power_simulation_period > 0,
-                                 self.load.monthly_peak_injection_simulation_period,
-                                 self.load.monthly_peak_extraction_simulation_period)
-                results_month_avg = Tb + self.load.monthly_average_injection_power_simulation_period * 1000 * (
+                power = np.where(monthly_average_injection_power > 0,
+                                 monthly_peak_injection,
+                                 monthly_peak_extraction)
+                results_month_avg = Tb + monthly_average_injection_power * 1000 * (
                         get_rb(results_temperature.baseload_temperature, Tmin,
                                power=power, temperature_borehole_wall=Tb) / self.number_of_boreholes / H_var)
 
                 # extra summation if the g-function value for the peak is included
                 results_peak_injection = (
                         Tb
-                        + (self.load.monthly_peak_injection_simulation_period
+                        + (monthly_peak_injection
                            * (g_value_peak_injection / k_s / 2 / pi + get_rb(results_temperature.peak_injection, Tmax,
-                                                                             self.load.monthly_peak_injection_simulation_period,
+                                                                             monthly_peak_injection,
                                                                              temperature_borehole_wall=Tb))
-                           - self.load.monthly_average_injection_power_simulation_period * g_value_peak_injection / k_s / 2 / pi)
+                           - monthly_average_injection_power * g_value_peak_injection / k_s / 2 / pi)
                         * 1000 / self.number_of_boreholes / H_var
                 )
-                results_peak_injection[self.load.monthly_peak_injection_simulation_period == 0] = Tb[
-                    self.load.monthly_peak_injection_simulation_period == 0]
+                results_peak_injection[monthly_peak_injection == 0] = Tb[
+                    monthly_peak_injection == 0]
 
                 results_peak_extraction = (
                         Tb +
-                        (- self.load.monthly_peak_extraction_simulation_period
+                        (- monthly_peak_extraction
                          * (g_value_peak_extraction / k_s / 2 / pi + get_rb(results_temperature.peak_extraction, Tmin,
-                                                                            self.load.monthly_peak_extraction_simulation_period * (
+                                                                            monthly_peak_extraction * (
                                                                                 -1), temperature_borehole_wall=Tb))
-                         - self.load.monthly_average_injection_power_simulation_period * g_value_peak_extraction / k_s / 2 / pi)
+                         - monthly_average_injection_power * g_value_peak_extraction / k_s / 2 / pi)
                         * 1000 / self.number_of_boreholes / H_var
                 )
 
-                results_peak_extraction[self.load.monthly_peak_extraction_simulation_period == 0] = Tb[
-                    self.load.monthly_peak_extraction_simulation_period == 0]
+                results_peak_extraction[monthly_peak_extraction == 0] = Tb[
+                    monthly_peak_extraction == 0]
 
                 # these results will be depreciated in v2.5.0
-                results_month_injection = Tb + self.load.monthly_baseload_injection_power_simulation_period * 1000 * (
+                results_month_injection = Tb + monthly_baseload_injection_power * 1000 * (
                         get_rb(results_temperature.monthly_injection, Tmax,
-                               self.load.monthly_baseload_injection_power_simulation_period,
+                               monthly_baseload_injection_power,
                                temperature_borehole_wall=Tb) / self.number_of_boreholes / H_var)
-                results_month_extraction = Tb - self.load.monthly_baseload_extraction_power_simulation_period * 1000 * (
+                results_month_extraction = Tb - monthly_baseload_extraction_power * 1000 * (
                         get_rb(results_temperature.monthly_extraction, Tmin,
-                               self.load.monthly_baseload_extraction_power_simulation_period,
+                               monthly_baseload_extraction_power,
                                temperature_borehole_wall=Tb) / self.number_of_boreholes / H_var)
 
                 # save temperatures under variable
@@ -2033,13 +2084,13 @@ class Borefield(BaseClass):
                 # calculate inlet/outlet temperatures when possible
                 if not self.borehole.use_constant_Rb:
                     results._baseload_temp_inlet, results._baseload_temp_outlet = self.calculate_borefield_inlet_outlet_temperature(
-                        self.load.monthly_average_injection_power_simulation_period, results.baseload_temperature,
+                        monthly_average_injection_power, results.baseload_temperature,
                         results.Tb)
                     results._peak_injection_inlet, results._peak_injection_outlet = self.calculate_borefield_inlet_outlet_temperature(
-                        self.load.monthly_peak_injection_simulation_period, results.peak_injection, results.Tb)
+                        monthly_peak_injection, results.peak_injection, results.Tb)
                     # (-1) needed since the peak power is always defined positive but for the Delta T it should be signed
                     results._peak_extraction_inlet, results._peak_extraction_outlet = self.calculate_borefield_inlet_outlet_temperature(
-                        (-1) * self.load.monthly_peak_extraction_simulation_period, results.peak_extraction, results.Tb)
+                        (-1) * monthly_peak_extraction, results.peak_extraction, results.Tb)
             if hourly:
                 # check for hourly data if this is requested
                 if not self.load._hourly:
@@ -2052,8 +2103,8 @@ class Borefield(BaseClass):
                     # convolution to get the hourly results
                     result_convolution = np.zeros_like(hourly_load, dtype=float)
 
-                    result_convolution[:max_idx + 1] = convolve(hourly_load[:max_idx + 1] * 1000, g_value_differences)[
-                        :max_idx + 1]
+                    result_convolution[:max_idx + 1] = self._convolve_with_kernel(
+                        hourly_load[:max_idx + 1] * 1000, g_value_differences)[:max_idx + 1]
 
                     self._temp_results['result_convolution'] = result_convolution
                     self._temp_results['hourly_load_prev'] = hourly_load.copy()
@@ -2074,7 +2125,7 @@ class Borefield(BaseClass):
                             first_idx:max_idx + 1]) * 1000
                         if len(delta) == 0:  # pragma: no cover
                             pass
-                        update = convolve(delta, g_value_differences)
+                        update = self._convolve_with_kernel(delta, g_value_differences)
 
                         self._temp_results['result_convolution'][first_idx:max_idx + 1] += update[
                             :max_idx - first_idx + 1]
@@ -2119,11 +2170,11 @@ class Borefield(BaseClass):
                                    hourly_load, temperature_borehole_wall=Tb) / self.number_of_boreholes / H_var)
                 if not self.borehole.use_constant_Rb:
                     results._Tf_inlet, results._Tf_outlet = self.calculate_borefield_inlet_outlet_temperature(
-                        hourly_load, results.peak_injection, results.Tb, simulation_period=self.load.simulation_period)
+                        hourly_load, results.peak_injection, results.Tb, simulation_period=load_simulation_period)
                     if sizing:
                         results._Tf_extraction_inlet, results._Tf_extraction_outlet = self.calculate_borefield_inlet_outlet_temperature(
                             hourly_load, results._Tf_extraction, results.Tb,
-                            simulation_period=self.load.simulation_period)
+                            simulation_period=load_simulation_period)
             return results
 
         def calculate_difference(


### PR DESCRIPTION
## What this does

The borehole wall temperature follows from Duhamel superposition of the ground load with the increments of the
g-function,

    Tb(t_n) = Tg + sum_k dQ_k [g(t_n - t_{k-1}) - g(t_n - t_k)] / (2 pi k_s H)

which GHEtool evaluates as a convolution of the load with the g-value differences. Within a sizing iteration the
borefield and H are fixed, so the *kernel* (the g-value differences) is constant while only the *signal* (the load)
changes. `scipy.signal.convolve` nevertheless re-transforms the kernel on every call.

- The rFFT of the kernel is cached and reused in the two iterative call sites of the hourly temperature calculation.
  The cache is keyed on transform length and validated against the **identity** of the kernel array, so a changed
  g-function cannot be served a stale transform. Transform length and method selection follow
  `scipy.signal.fftconvolve`, and anything `choose_conv_method` does not route to `'fft'` is delegated to
  `scipy.signal.convolve`, so the returned array is the one scipy would return. The single-shot monthly convolution
  is deliberately left as a plain `convolve`, since there is no reuse to exploit there.
- The load properties used in the monthly temperature profile are hoisted into locals. For building loads every
  attribute access re-evaluates the full COP/EER chain, so reading each once per profile rather than once per use is
  a real saving and changes no value.

## Measured

6x6 field, 20-year hourly building load with temperature-dependent COP/EER, stock pygfunction 2.3.1. Best and median
of 11 (profile) and 7 (sizing) repetitions:

| workload | upstream (best / median) | this branch (best / median) | change |
|---|---|---|---|
| hourly temperature profile | 0.0543 s / 0.0559 s | 0.0448 s / 0.0481 s | **-17% / -14%** |
| L4 sizing | 0.7187 s / 0.7833 s | 0.5894 s / 0.6468 s | **-18% / -17%** |

Reproduced across two independent benchmark runs; run-to-run noise on this machine is about +-8%, so the effect is
comfortably outside it.

## Tests

Full unit-test suite: **509 passed**, identical to `upstream/main` on the same machine and environment.

---

### AI usage disclosure

This contribution was prepared with AI assistance (Claude, via Claude Code). The implementation, the tests and this
description were drafted with the model and then reviewed, run and validated by me; I am responsible for what is
proposed here. Every number quoted above was produced by running the code locally against stock `pygfunction 2.3.1`
from PyPI (not the author's fork, and not generated by the model). Commits carry a `Co-Authored-By: Claude` trailer.
