### PR TITLE
Memoise the hourly building-to-geothermal load conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Memoise the conversion from hourly building loads to geothermal loads.
 - Move calculate_borefield_inlet_outlet_temperature to Borehole class (issue #464).
 - Change implementation ConicalProbe for speed improvement (issue #472).
 - Change implementation of interpolation for _Efficiency class to cope with non-gridded data input (issue #472).

--- a/GHEtool/VariableClasses/LoadData/Baseclasses/_HourlyDataBuilding.py
+++ b/GHEtool/VariableClasses/LoadData/Baseclasses/_HourlyDataBuilding.py
@@ -44,6 +44,7 @@ class _HourlyDataBuilding(_LoadDataBuilding, _HourlyData, ABC):
         self._hourly_heating_load: np.ndarray = np.zeros(8760)
         self._hourly_cooling_load: np.ndarray = np.zeros(8760)
         self._hourly_dhw_load: np.ndarray = None
+        self._hourly_load_cache: dict = {}
         self._set_dhw(dhw)
 
         # delete unnecessary variables
@@ -155,6 +156,72 @@ class _HourlyDataBuilding(_LoadDataBuilding, _HourlyData, ABC):
             self.hourly_dhw_load = np.full(8760, dhw / 8760)
             return
         self.hourly_dhw_load = dhw
+
+    def _hourly_load_memo(self, key: str, load_array: np.ndarray, temperature_index: int, compute):
+        """
+        This function memoises the (expensive) conversion from a building load to a geothermal load.
+        The cached value is only returned when all the inputs which determine the result are unchanged:
+        the raw load array and the efficiency objects (compared by identity, they are replaced upon
+        assignment) and the temperature results (compared by value, so also in-place changes are
+        detected). During iterative calculations these properties are requested over and over with
+        unchanged inputs, so this saves a lot of time. Whenever any input changed, the value is
+        recomputed, so the result is always identical to an uncached calculation.
+
+        Parameters
+        ----------
+        key : str
+            Name of the cached property.
+        load_array : np.ndarray
+            The raw (building) load array the property is based on.
+        temperature_index : int
+            Index of the fixed temperature results relevant for this property
+            (0 for extraction/heating, 1 for injection/cooling).
+        compute : callable
+            Function without arguments that computes the property value.
+
+        Returns
+        -------
+        value : np.ndarray
+        """
+        if self._limit_to_max_heat_pump_power:
+            # this path also depends on the maximum heat pump power, do not cache
+            return compute()
+
+        if getattr(self, '_hourly_load_cache', None) is None:
+            self._hourly_load_cache = {}
+
+        # determine the temperature state the result depends upon
+        if isinstance(self.cop, SCOP) and isinstance(self.eer, SEER) and isinstance(self.cop_dhw, SCOP):
+            temperature_state = None  # result is independent of the temperature results
+        elif isinstance(self.results, tuple):
+            temperature_state = self.results[temperature_index]
+        elif isinstance(self.results, ResultsHourly):
+            temperature_state = self.results.Tf
+        else:
+            # monthly results; the computation itself raises a TypeError
+            return compute()
+
+        # nb. the simulation period of multiyear loads is captured by the identity of the load array
+        dependencies = (load_array, self._cop, self._eer, self._cop_dhw,
+                        getattr(self._eer, 'threshold_temperature', None),
+                        getattr(self, '_simulation_period', None), getattr(self, '_start_month', None),
+                        self._all_months_equal)
+
+        entry = self._hourly_load_cache.get(key)
+        if entry is not None:
+            old_dependencies, old_temperature, value = entry
+            if len(old_dependencies) == len(dependencies) \
+                    and all(old is new for old, new in zip(old_dependencies, dependencies)) \
+                    and (temperature_state is None if old_temperature is None else
+                         np.array_equal(old_temperature, temperature_state)):
+                return value.copy()
+
+        value = compute()
+        self._hourly_load_cache[key] = (
+            dependencies,
+            temperature_state.copy() if isinstance(temperature_state, np.ndarray) else temperature_state,
+            value.copy())
+        return value
 
     def _get_hourly_cop(self, power: np.ndarray = None) -> Union[float, np.ndarray]:
         """
@@ -338,14 +405,17 @@ class _HourlyDataBuilding(_LoadDataBuilding, _HourlyData, ABC):
         hourly injection : np.ndarray
             Hourly injection values [kWh/h] for the whole simulation period
         """
-        part_load = self.hourly_cooling_load_simulation_period
-        if self._limit_to_max_heat_pump_power:
+        def compute():
+            part_load = self.hourly_cooling_load_simulation_period
+            if self._limit_to_max_heat_pump_power:
+                return np.multiply(
+                    self._get_max_power_cooling,
+                    self.conversion_factor_secondary_to_primary_cooling(self._get_hourly_eer(part_load)))
             return np.multiply(
-                self._get_max_power_cooling,
+                self.hourly_cooling_load_simulation_period,
                 self.conversion_factor_secondary_to_primary_cooling(self._get_hourly_eer(part_load)))
-        return np.multiply(
-            self.hourly_cooling_load_simulation_period,
-            self.conversion_factor_secondary_to_primary_cooling(self._get_hourly_eer(part_load)))
+
+        return self._hourly_load_memo('injection', self._hourly_cooling_load, 1, compute)
 
     @property
     def hourly_extraction_load_simulation_period(self) -> np.ndarray:
@@ -357,6 +427,9 @@ class _HourlyDataBuilding(_LoadDataBuilding, _HourlyData, ABC):
         hourly extraction : np.ndarray
             Hourly extraction values [kWh/h] for the whole simulation period
         """
+        if not np.any(self.hourly_dhw_load_simulation_period):
+            # no DHW, so the (expensive) DHW extraction load calculation can be skipped
+            return self._hourly_extraction_load_heating_simulation_period
         return self._hourly_extraction_load_heating_simulation_period + self._hourly_extraction_load_dhw_simulation_period
 
     @property
@@ -369,14 +442,17 @@ class _HourlyDataBuilding(_LoadDataBuilding, _HourlyData, ABC):
         hourly extraction : np.ndarray
             Hourly extraction values [kWh/h] for the whole simulation period
         """
-        part_load = self.hourly_heating_load_simulation_period
-        if self._limit_to_max_heat_pump_power:
+        def compute():
+            part_load = self.hourly_heating_load_simulation_period
+            if self._limit_to_max_heat_pump_power:
+                return np.multiply(
+                    self._get_max_power_heating,
+                    self.conversion_factor_secondary_to_primary_heating(self._get_hourly_cop(part_load)))
             return np.multiply(
-                self._get_max_power_heating,
+                self.hourly_heating_load_simulation_period,
                 self.conversion_factor_secondary_to_primary_heating(self._get_hourly_cop(part_load)))
-        return np.multiply(
-            self.hourly_heating_load_simulation_period,
-            self.conversion_factor_secondary_to_primary_heating(self._get_hourly_cop(part_load)))
+
+        return self._hourly_load_memo('extraction_heating', self._hourly_heating_load, 0, compute)
 
     @property
     def _hourly_extraction_load_dhw_simulation_period(self) -> np.ndarray:
@@ -388,14 +464,17 @@ class _HourlyDataBuilding(_LoadDataBuilding, _HourlyData, ABC):
         hourly extraction : np.ndarray
             Hourly extraction values [kWh/h] for the whole simulation period
         """
-        part_load_dhw = self.hourly_dhw_load_simulation_period
-        if self._limit_to_max_heat_pump_power:
-            return np.multiply(self._get_max_power_dhw,
-                               self.conversion_factor_secondary_to_primary_heating(
-                                   self._get_hourly_cop_dhw(part_load_dhw)))
-        return np.multiply(
-            self.hourly_dhw_load_simulation_period,
-            self.conversion_factor_secondary_to_primary_heating(self._get_hourly_cop_dhw(part_load_dhw)))
+        def compute():
+            part_load_dhw = self.hourly_dhw_load_simulation_period
+            if self._limit_to_max_heat_pump_power:
+                return np.multiply(self._get_max_power_dhw,
+                                   self.conversion_factor_secondary_to_primary_heating(
+                                       self._get_hourly_cop_dhw(part_load_dhw)))
+            return np.multiply(
+                self.hourly_dhw_load_simulation_period,
+                self.conversion_factor_secondary_to_primary_heating(self._get_hourly_cop_dhw(part_load_dhw)))
+
+        return self._hourly_load_memo('extraction_dhw', self._hourly_dhw_load, 0, compute)
 
     @property
     def monthly_baseload_heating_simulation_period(self) -> np.ndarray:


### PR DESCRIPTION
## What this does

Converting an hourly *building* load to the ground load requires evaluating the heat pump efficiency at every hour:

    Q_ground,extraction = Q_building,heating * (1 - 1/COP(Tf, ...))
    Q_ground,injection  = Q_building,cooling * (1 + 1/EER(Tf, ...))

With temperature-dependent efficiencies this is an `8760 * simulation_period` interpolation per property access, and
the iterative temperature calculation requests the same properties repeatedly with unchanged inputs.

The conversion is memoised, with an invalidation rule that mirrors what the result actually depends on:

- the raw load array and the COP/EER/COP_dhw objects are compared **by identity** (they are replaced on assignment,
  never mutated in place),
- the fluid temperature results are compared **by value**, so in-place changes to the results are detected,
- the simulation period, start month and `all_months_equal` flag enter the key,
- the `limit_to_max_heat_pump_power` path is **never** cached, since it depends on additional state.

When the efficiencies are all SCOP/SEER the result is independent of the temperature results and the temperature
state drops out of the key entirely.

Also skips the DHW extraction-load calculation when there is no DHW demand, matching what the monthly variant
already does.

## Measured

6x6 field, 20-year hourly building load with temperature-dependent COP/EER. Best and median of 11 (profile) and
7 (sizing):

| workload | upstream (best / median) | this branch (best / median) | change |
|---|---|---|---|
| L4 sizing | 0.7187 s / 0.7833 s | 0.6708 s / 0.7249 s | -7% / -7% |
| hourly temperature profile | 0.0543 s / 0.0559 s | 0.0517 s / 0.0570 s | within noise |

Honest reading: the sizing gain is consistent in direction across runs but sits close to the +-8% noise band on this
machine, and the single-profile case shows nothing. This is the weakest of the performance changes in the series,
and it is also the one that adds the most machinery. If you would rather not take on the invalidation logic for a
gain this size, that is a reasonable call and I will close it.

I would expect the benefit to grow with the number of temperature iterations and with longer simulation periods, but
I have not found a workload where it is unambiguous, and I would rather say so than quote a favourable number.

## Tests

Full unit-test suite: **509 passed**, identical to `upstream/main`.

---

### AI usage disclosure

This contribution was prepared with AI assistance (Claude, via Claude Code). The implementation, the tests and this
description were drafted with the model and then reviewed, run and validated by me; I am responsible for what is
proposed here. Every number quoted above was produced by running the code locally against stock `pygfunction 2.3.1`
from PyPI (not the author's fork, and not generated by the model). Commits carry a `Co-Authored-By: Claude` trailer.
