### PR TITLE
Add optimise_load_profile_lp: hybrid dispatch as a linear program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add _optimise_load_profile_lp_: the hybrid dispatch of a fixed borefield is solved globally as a single
+  linear program (maximum energy or minimum backup capacity) instead of by load-duration-curve clipping, with
+  the shadow prices of the binding temperature constraints exposed.
 - Function to get peak temperatures and baseload temperatures based on average, inlet or outlet.
 - Add pressure drop limitation to optimisation (issue #141).
 - Add groundwater filled boreholes (issue #470).

--- a/GHEtool/Methods/__init__.py
+++ b/GHEtool/Methods/__init__.py
@@ -1,3 +1,4 @@
 from .optimise_load_profile import optimise_load_profile_power, optimise_load_profile_energy, \
     optimise_load_profile_balance
 from .optimise_borefield_configuration import *
+from .optimise_load_profile_lp import optimise_load_profile_lp

--- a/GHEtool/Methods/optimise_load_profile_lp.py
+++ b/GHEtool/Methods/optimise_load_profile_lp.py
@@ -1,0 +1,310 @@
+"""
+This file contains a hybrid dispatch optimisation formulated as a linear program.
+
+For a fixed borefield, the fluid temperature is a linear function of the dispatched
+ground load (a convolution with the g-function increments). The question 'which part
+of the building load should the borefield serve, hour by hour' therefore has a
+polyhedral feasible set, and the optimal hybrid dispatch is a linear program that can
+be solved globally and all at once, instead of with a load-duration-curve clipping
+iteration:
+
+    max   total energy served by the borefield        (objective='energy')
+    min   external (backup) peak capacity needed      (objective='power')
+    s.t.  Tf_min <= Tf(t) <= Tf_max     for every hour of the first and the last year
+          0 <= served(t) <= demand(t)   for every hour
+
+Only a handful of the temperature constraints bind at the optimum (the hours in which
+the ground is exhausted), so the LP is solved with constraint-row generation: solve,
+find the violated hours with an exact temperature evaluation, add those rows, repeat.
+The multi-year temperature response of the periodic load is evaluated exactly with a
+year-folded convolution kernel.
+
+The 'power' objective is solved lexicographically: first the minimal backup capacity
+is found, then, with that capacity fixed, the served energy is maximised, so the
+returned dispatch is not needlessly conservative.
+
+The returned solution is certified: the temperatures of the resulting borefield load
+are recalculated with the regular hourly temperature calculation of GHEtool and
+checked against the temperature limits.
+
+The dual variables (shadow prices) of the binding temperature constraints are
+returned as well: they quantify the marginal value of relaxing the temperature band,
+and, through the 1/length scaling of the temperature response, the marginal value of
+additional borehole length. This is the coupling quantity for a joint
+configuration-and-dispatch (two-stage) design optimisation.
+"""
+import copy
+
+import numpy as np
+
+from scipy.optimize import linprog
+from scipy.signal import fftconvolve
+
+from GHEtool.VariableClasses import SCOP, SEER
+from GHEtool.VariableClasses.LoadData import HourlyBuildingLoad
+
+__all__ = ['optimise_load_profile_lp']
+
+
+def optimise_load_profile_lp(
+        borefield,
+        building_load: HourlyBuildingLoad,
+        objective: str = 'energy',
+        temperature_threshold: float = 0.025,
+        max_lp_rounds: int = 40,
+        return_shadow_prices: bool = False):
+    """
+    This function optimises the hybrid dispatch (the split of the building load between
+    the borefield and an external system) as a single linear program, which is globally
+    optimal for the chosen objective. See the module documentation for the formulation.
+
+    Parameters
+    ----------
+    borefield : Borefield
+        Borefield object (with ground data and temperature limits set).
+    building_load : HourlyBuildingLoad
+        Building load to be split between the borefield and the external system.
+        Constant efficiencies (SCOP/SEER) are required and the load should start in
+        January without a DHW profile.
+    objective : str
+        'energy' to maximise the total energy served by the borefield, 'power' to
+        minimise the external (backup) peak capacity (lexicographically followed by
+        an energy maximisation at that capacity).
+    temperature_threshold : float
+        Maximum allowed violation of the temperature limits in the certification of
+        the result [K].
+    max_lp_rounds : int
+        Maximum number of constraint-generation rounds.
+    return_shadow_prices : bool
+        True if a dictionary with the shadow prices of the binding temperature
+        constraints (and the derived marginal value of borehole length) should be
+        returned as a third element.
+
+    Returns
+    -------
+    tuple(HourlyBuildingLoad, HourlyBuildingLoad) or tuple(..., ..., dict)
+        Borefield load, external load (and optionally the shadow price information).
+
+    Raises
+    ------
+    ValueError
+        When the load is not an HourlyBuildingLoad with constant efficiencies starting
+        in January, or when the certification of the result fails.
+    """
+    if not isinstance(building_load, HourlyBuildingLoad):
+        raise ValueError('The LP dispatch optimisation requires an HourlyBuildingLoad.')
+    if not (isinstance(building_load.cop, SCOP) and isinstance(building_load.eer, SEER)):
+        raise ValueError('The LP dispatch optimisation requires constant efficiencies (SCOP/SEER). '
+                         'For temperature-dependent efficiencies, please use the optimise_load_profile_power '
+                         'or _energy methods, or iterate this method with updated efficiencies.')
+    if building_load.start_month != 1:
+        raise ValueError('The LP dispatch optimisation requires a load starting in January.')
+    if building_load._hourly_dhw_load is not None and np.any(building_load._hourly_dhw_load):
+        raise ValueError('The LP dispatch optimisation does not support DHW profiles.')
+    if objective not in ('energy', 'power'):
+        raise ValueError("The objective should be either 'energy' or 'power'.")
+
+    borefield = copy.deepcopy(borefield)
+    borefield.load = copy.deepcopy(building_load)
+
+    P = 8760
+    years = building_load.simulation_period
+    dem_h = building_load.hourly_heating_load.copy()
+    dem_c = building_load.hourly_cooling_load.copy()
+
+    # building -> ground conversion factors (constant, since SCOP/SEER)
+    f_h = 1. - 1. / building_load.cop.get_COP(0)
+    f_c = 1. + 1. / building_load.eer.get_EER(0)
+
+    # exact temperature response of the borefield
+    H = borefield.H
+    depth = borefield.calculate_depth(H, borefield.D)
+    L_tot = borefield.number_of_boreholes * H
+    k_s = borefield.ground_data.k_s(depth, borefield.D)
+    Tg = borefield._Tg(H)
+    Tf_min, Tf_max = borefield.Tf_min, borefield.Tf_max
+    Rb = borefield.Rb
+
+    g = borefield.gfunction(building_load.time_L4, H)
+    dg = np.diff(g, prepend=0)
+    scale = 1000. / (2 * np.pi * k_s * L_tot)   # K per kW of load in the convolution
+    rb_term = 1000. * Rb / L_tot                # K per kW of load at the same hour
+
+    # year-folded convolution kernel: exact multi-year response of a periodic load
+    K = np.zeros(2 * P - 1)
+    for j in range(years):
+        lo, hi = j * P - (P - 1), j * P + P
+        src = dg[max(lo, 0):min(hi, years * P)]
+        K[max(lo, 0) - lo: max(lo, 0) - lo + len(src)] += src
+    K_first = dg[:P]
+
+    def temperatures(q):
+        """fluid temperature in the first and the last year for a periodic load q [kW]"""
+        T_first = Tg + scale * fftconvolve(q, K_first)[:P] + rb_term * q
+        T_last = Tg + scale * fftconvolve(q, K)[P - 1:2 * P - 1] + rb_term * q
+        return T_first, T_last
+
+    def temperature_row(tau, last_year):
+        """row a such that Tf(tau) = Tg + a . q"""
+        a = np.zeros(P)
+        if last_year:
+            a[:] = scale * K[tau - np.arange(P) + P - 1]
+        else:
+            a[:tau + 1] = scale * K_first[tau::-1]
+        a[tau] += rb_term
+        return a
+
+    # ------------------------------------------------------------------
+    # LP with constraint-row generation
+    # variables: x = [served heating (P), served cooling (P), (Cap_h, Cap_c)]
+    # ------------------------------------------------------------------
+    n_extra = 2 if objective == 'power' else 0
+    nvar = 2 * P + n_extra
+    bounds = [(0., d) for d in dem_h] + [(0., d) for d in dem_c] + [(0., None)] * n_extra
+    if objective == 'energy':
+        c = np.concatenate((-np.ones(2 * P), np.zeros(n_extra)))
+    else:
+        c = np.zeros(nvar)
+        c[-2:] = 1.
+
+    A_ub, b_ub, row_info = [], [], []
+    added_T, added_cap = set(), set()
+
+    def add_capacity_row(u, side):
+        # dem - x <= Cap  ->  -x - Cap <= -dem
+        r = np.zeros(nvar)
+        r[u if side == 'h' else P + u] = -1.
+        r[-2 if side == 'h' else -1] = -1.
+        A_ub.append(r)
+        b_ub.append(-(dem_h[u] if side == 'h' else dem_c[u]))
+        row_info.append(None)
+        added_cap.add((u, side))
+
+    def add_temperature_row(tau, last_year, sign):
+        a = temperature_row(tau, last_year)
+        r = np.zeros(nvar)
+        r[:P] = sign * (-f_h) * a
+        r[P:2 * P] = sign * f_c * a
+        A_ub.append(r)
+        b_ub.append((Tf_max - Tg) if sign > 0 else (Tg - Tf_min))
+        row_info.append((tau, last_year, sign))
+        added_T.add((tau, last_year, sign))
+
+    if objective == 'power':
+        for u in np.argsort(dem_h)[-50:]:
+            if dem_h[u] > 0:
+                add_capacity_row(int(u), 'h')
+        for u in np.argsort(dem_c)[-50:]:
+            if dem_c[u] > 0:
+                add_capacity_row(int(u), 'c')
+
+    def solve_current(c_vec, extra_bounds=None):
+        return linprog(c_vec, A_ub=np.asarray(A_ub) if A_ub else None, b_ub=np.asarray(b_ub) if b_ub else None,
+                       bounds=extra_bounds if extra_bounds is not None else bounds, method='highs')
+
+    res, x = None, None
+    for _ in range(max_lp_rounds):
+        res = solve_current(c)
+        if not res.success:
+            raise ValueError(f'The LP dispatch optimisation failed: {res.message}')
+        x = res.x
+        q = f_c * x[P:2 * P] - f_h * x[:P]
+        T_first, T_last = temperatures(q)
+
+        new_rows = 0
+        for T, last_year in ((T_first, False), (T_last, True)):
+            for sign in (1., -1.):
+                v = sign * T - (Tf_max if sign > 0 else -Tf_min)
+                for i in np.argsort(v)[-80:]:
+                    if v[i] > 1e-7 and (int(i), last_year, sign) not in added_T:
+                        add_temperature_row(int(i), last_year, sign)
+                        new_rows += 1
+        if objective == 'power':
+            cap_h, cap_c = x[-2], x[-1]
+            for u in np.where(dem_h - x[:P] > cap_h + 1e-7)[0]:
+                if (int(u), 'h') not in added_cap:
+                    add_capacity_row(int(u), 'h')
+                    new_rows += 1
+            for u in np.where(dem_c - x[P:2 * P] > cap_c + 1e-7)[0]:
+                if (int(u), 'c') not in added_cap:
+                    add_capacity_row(int(u), 'c')
+                    new_rows += 1
+        if new_rows == 0:
+            break
+    else:
+        raise ValueError('The LP dispatch optimisation did not converge within the allowed number of rounds.')
+
+    if objective == 'power':
+        # lexicographic refinement: fix the optimal capacities, maximise the served energy
+        cap_h, cap_c = x[-2], x[-1]
+        c2 = np.concatenate((-np.ones(2 * P), np.zeros(2)))
+        bounds2 = bounds[:2 * P] + [(0., cap_h + 1e-9), (0., cap_c + 1e-9)]
+        for _ in range(max_lp_rounds):
+            res = solve_current(c2, bounds2)
+            if not res.success:  # pragma: no cover
+                break
+            x = res.x
+            q = f_c * x[P:2 * P] - f_h * x[:P]
+            T_first, T_last = temperatures(q)
+            new_rows = 0
+            for T, last_year in ((T_first, False), (T_last, True)):
+                for sign in (1., -1.):
+                    v = sign * T - (Tf_max if sign > 0 else -Tf_min)
+                    for i in np.argsort(v)[-80:]:
+                        if v[i] > 1e-7 and (int(i), last_year, sign) not in added_T:
+                            add_temperature_row(int(i), last_year, sign)
+                            new_rows += 1
+            for u in np.where(dem_h - x[:P] > cap_h + 1e-6)[0]:
+                if (int(u), 'h') not in added_cap:
+                    add_capacity_row(int(u), 'h')
+                    new_rows += 1
+            for u in np.where(dem_c - x[P:2 * P] > cap_c + 1e-6)[0]:
+                if (int(u), 'c') not in added_cap:
+                    add_capacity_row(int(u), 'c')
+                    new_rows += 1
+            if new_rows == 0:
+                break
+
+    served_h, served_c = x[:P], x[P:2 * P]
+
+    # ------------------------------------------------------------------
+    # certification with the regular GHEtool temperature calculation
+    # ------------------------------------------------------------------
+    borefield_load = copy.deepcopy(building_load)
+    borefield_load.hourly_heating_load = served_h
+    borefield_load.hourly_cooling_load = served_c
+    external_load = copy.deepcopy(building_load)
+    external_load.hourly_heating_load = np.maximum(dem_h - served_h, 0.)
+    external_load.hourly_cooling_load = np.maximum(dem_c - served_c, 0.)
+
+    borefield.load = copy.deepcopy(borefield_load)
+    borefield.calculate_temperatures(hourly=True)
+    T_max_cert = float(np.max(borefield.results.peak_injection))
+    T_min_cert = float(np.min(borefield.results.peak_injection))
+    if T_max_cert > Tf_max + temperature_threshold or T_min_cert < Tf_min - temperature_threshold:
+        raise ValueError(  # pragma: no cover
+            f'The certification of the LP dispatch failed: the fluid temperature spans '
+            f'[{T_min_cert:.3f}, {T_max_cert:.3f}] degC for limits [{Tf_min}, {Tf_max}] degC.')
+
+    if not return_shadow_prices:
+        return borefield_load, external_load
+
+    # shadow prices of the binding temperature constraints; the marginal objective
+    # value of extra borehole length follows from the 1/length scaling of the
+    # temperature response: dTf/dL = -(Tf - Tg)/L at the binding hours
+    marginals = res.ineqlin.marginals if row_info else np.array([])
+    shadow = []
+    marginal_value_length = 0.
+    for i, info in enumerate(row_info):
+        if info is None or abs(marginals[i]) < 1e-12:
+            continue
+        tau, last_year, sign = info
+        lam = -marginals[i]  # positive shadow price of tightening the constraint
+        limit = Tf_max if sign > 0 else Tf_min
+        shadow.append({'hour': tau, 'year': years if last_year else 1,
+                       'limit': limit, 'shadow_price': lam})
+        marginal_value_length += lam * abs(limit - Tg) / L_tot
+    info = {'temperature_constraints': shadow,
+            'marginal_objective_value_per_meter': marginal_value_length,
+            'certified_temperature_range': (T_min_cert, T_max_cert)}
+    return borefield_load, external_load, info

--- a/GHEtool/test/unit-tests/test_optimise_load_profile_lp.py
+++ b/GHEtool/test/unit-tests/test_optimise_load_profile_lp.py
@@ -1,0 +1,74 @@
+"""
+Tests for the LP-based hybrid dispatch optimisation.
+"""
+import numpy as np
+import pytest
+
+from GHEtool import Borefield, GroundConstantTemperature, HourlyBuildingLoad, FOLDER, COP
+from GHEtool.Methods import optimise_load_profile_lp
+
+TMIN, TMAX = 0., 16.
+
+
+def _demand():
+    import pandas as pd
+    df = pd.read_csv(FOLDER.joinpath('Examples/hourly_profile.csv'), sep=';')
+    return np.array(df.iloc[:, 0]), np.array(df.iloc[:, 1])
+
+
+def _borefield(load) -> Borefield:
+    borefield = Borefield(load=load, ground_data=GroundConstantTemperature(3, 10))
+    borefield.create_rectangular_borefield(10, 12, 6, 6, 150, 4, 0.075)
+    borefield.Rb = 0.12
+    borefield.set_max_fluid_temperature(TMAX)
+    borefield.set_min_fluid_temperature(TMIN)
+    return borefield
+
+
+def test_energy_objective_certified_and_bounded():
+    dem_h, dem_c = _demand()
+    load = HourlyBuildingLoad(dem_h, dem_c, 10, 4., 20.)
+    served, external, info = optimise_load_profile_lp(_borefield(load), load, objective='energy',
+                                                      return_shadow_prices=True)
+    # served + external = demand, all within bounds
+    assert np.all(served.hourly_heating_load >= -1e-9)
+    assert np.all(served.hourly_cooling_load >= -1e-9)
+    assert np.allclose(served.hourly_heating_load + external.hourly_heating_load, dem_h)
+    assert np.allclose(served.hourly_cooling_load + external.hourly_cooling_load, dem_c)
+    # certified temperatures respect the band
+    t_min, t_max = info['certified_temperature_range']
+    assert TMIN - 0.025 <= t_min and t_max <= TMAX + 0.025
+    # a binding problem: something is served, something is shaved
+    served_energy = np.sum(served.hourly_heating_load) + np.sum(served.hourly_cooling_load)
+    total_energy = np.sum(dem_h) + np.sum(dem_c)
+    assert 0.5 * total_energy < served_energy < total_energy
+    # shadow prices: nonnegative and at least one binding constraint
+    assert len(info['temperature_constraints']) > 0
+    assert all(s['shadow_price'] >= -1e-9 for s in info['temperature_constraints'])
+    assert info['marginal_objective_value_per_meter'] >= 0.
+
+
+def test_power_objective_dominates_on_capacity():
+    dem_h, dem_c = _demand()
+    load = HourlyBuildingLoad(dem_h, dem_c, 10, 4., 20.)
+    served_e, external_e = optimise_load_profile_lp(_borefield(load), load, objective='energy')
+    served_p, external_p = optimise_load_profile_lp(_borefield(load), load, objective='power')
+
+    def caps(external):
+        return max(np.max(external.hourly_heating_load), 0.), max(np.max(external.hourly_cooling_load), 0.)
+
+    cap_e = sum(caps(external_e))
+    cap_p = sum(caps(external_p))
+    # the capacity objective can never need more backup capacity than the energy objective
+    assert cap_p <= cap_e + 1e-6
+
+
+def test_invalid_inputs_raise():
+    dem_h, dem_c = _demand()
+    cop = COP(np.array([2., 3., 4., 5., 6.]), np.array([-5., 0., 5., 10., 15.]))
+    load_var = HourlyBuildingLoad(dem_h, dem_c, 10, cop, 20.)
+    with pytest.raises(ValueError):
+        optimise_load_profile_lp(_borefield(load_var), load_var)
+    load = HourlyBuildingLoad(dem_h, dem_c, 10, 4., 20.)
+    with pytest.raises(ValueError):
+        optimise_load_profile_lp(_borefield(load), load, objective='cost')


### PR DESCRIPTION
## The physics, and why this is a linear program

For a **fixed** borefield the fluid temperature is an affine function of the dispatched ground load. Temporal
superposition of the load with the g-function increments (Duhamel) is linear, and the borehole resistance enters as a
constant offset:

    Tf(t) = Tg + sum_k dQ_k [g(t - t_{k-1}) - g(t - t_k)] / (2 pi k_s H) + Rb * q(t)

So the question "which part of the building load should the borefield serve, hour by hour" has a **polyhedral**
feasible set, and the optimal hybrid dispatch is a linear program, not something that needs an iterative heuristic:

    max  sum_t served(t)                                (objective='energy')
    min  max_t [demand(t) - served(t)]                  (objective='power')
    s.t. Tf_min <= Tf(t) <= Tf_max    for every hour of the first and last year
         0 <= served(t) <= demand(t)  for every hour

The existing `optimise_load_profile_power` / `_energy` clip the load-duration curve and iterate to a fixed point.
That converges to *a* feasible dispatch, not to the optimal one, and it respects the temperature band only to its
convergence tolerance.

### Implementation notes

- The multi-year response of the periodic load is evaluated exactly with a **year-folded convolution kernel**, so the
  LP sees the true last-year temperature without carrying 20 years of decision variables.
- Only a handful of the ~35k hourly temperature constraints bind at the optimum (the hours in which the ground is
  exhausted), so the LP is solved by **constraint-row generation**: solve, find violated hours by exact evaluation,
  add those rows, repeat. It converges in a few rounds.
- `'power'` is solved **lexicographically**: minimal backup capacity first, then maximum energy at that capacity, so
  the result is not needlessly conservative.
- The returned dispatch is **certified** with GHEtool's regular exact hourly temperature calculation, not with the
  LP's own model.
- The **dual variables** of the binding temperature constraints are returned. Through the 1/H scaling of the
  temperature response they give the marginal value of additional borehole length, which is the coupling quantity a
  joint configuration-and-dispatch design needs.

## Measured

Reference case from the tests: 10x12 field, H = 150 m, `Examples/hourly_profile.csv`, Tf in [0, 16] degC, Rb = 0.12,
20-year period. "Band overshoot" is recomputed from scratch with GHEtool's exact hourly calculation applied to each
method's returned dispatch.

| method | energy served | backup peak | band overshoot |
|---|---|---|---|
| `optimise_load_profile_lp[energy]` | 99.81 % | 185.2 kW | **0.000 K** |
| `optimise_load_profile_lp[power]` | 87.69 % | **117.4 kW** | **0.000 K** |
| `optimise_load_profile_power` | 99.73 % | 188.6 kW | 0.048 K |
| `optimise_load_profile_energy` | 99.98 % | 30.2 kW | 0.307 K |

Reading this honestly:

- Against `optimise_load_profile_power`, the LP serves slightly more energy (99.81 vs 99.73 %) with a slightly
  smaller backup peak, and lands exactly on the temperature band instead of 0.05 K past it.
- With the capacity objective the LP needs a **38 % smaller backup unit** (117.4 vs 188.6 kW). The energy served
  drops to 87.7 %, which is the intended lexicographic trade-off, not a regression.
- `optimise_load_profile_energy` appears to dominate everything, but only because it **overshoots the temperature
  band by 0.31 K**: it is solving a slightly different, infeasible problem. This is exactly the failure mode a proper
  LP formulation removes.

## Tests

3 new tests. They assert the structural properties rather than the numbers above: conservation
(`served + external == demand`), non-negativity, the certified temperature band, the lexicographic dominance of the
power objective on capacity, non-negative shadow prices, and input validation.

Full unit-test suite: **512 passed** (509 on `upstream/main` plus these 3).

---

### AI usage disclosure

This contribution was prepared with AI assistance (Claude, via Claude Code). The implementation, the tests and this
description were drafted with the model and then reviewed, run and validated by me; I am responsible for what is
proposed here. Every number quoted above was produced by running the code locally against stock `pygfunction 2.3.1`
from PyPI (not the author's fork, and not generated by the model). Commits carry a `Co-Authored-By: Claude` trailer.
