### PR TITLE
Add DecoupledGFunction: cylindrically corrected g-functions without the solver monkeypatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add _DecoupledGFunction_: computes the cylindrically corrected g-function on pygfunction's public solvers,
+  adding the correction as a separable single-borehole early-time delta instead of monkeypatching
+  pygfunction's solver. Uses the Laplace-domain solver when the installed pygfunction has one.
 - Function to get peak temperatures and baseload temperatures based on average, inlet or outlet.
 - Add pressure drop limitation to optimisation (issue #141).
 - Add groundwater filled boreholes (issue #470).

--- a/GHEtool/VariableClasses/Gfunctions/DecoupledGFunction.py
+++ b/GHEtool/VariableClasses/Gfunctions/DecoupledGFunction.py
@@ -1,0 +1,232 @@
+"""
+g-functions on pygfunction's public solvers, without the solver monkeypatch.
+
+Motivation
+----------
+GHEtool historically computes g-functions through a *monkeypatch* of pygfunction's
+solver (see :mod:`GHEtool.VariableClasses.Cylindrical_correction`), replacing
+``_BaseSolver.solve``/``__init__`` and ``Equivalent.thermal_response_factors`` to inject
+the finite-radius *cylindrical correction* that upstream pygfunction lacks. That patch
+also bypasses any solver improvement made upstream.
+
+Newer pygfunction exposes a Laplace-domain solver (``method='laplace'``) that reconstructs
+the g-function as a sum of decaying exponentials. Its cost is *independent* of the number
+of requested time values and it yields the exact continuous-time g-function, evaluable at
+any instant. This module lets GHEtool ride that solver (or any public pygfunction solver)
+*without* the monkeypatch, and re-adds the cylindrical correction as a thin, provably
+field-independent early-time delta.
+
+Why the correction is separable
+-------------------------------
+The cylindrical correction only modifies each borehole's *self*-response, and only at
+early times (t ~ r_b^2 / alpha). At those times the thermal radius sqrt(alpha*t) is far
+smaller than the borehole spacing, so the boreholes are thermally isolated and the
+correction's effect on the field g-function equals the single-borehole correction. This is
+verified numerically: the single-borehole delta reproduces the full-field cylindrical
+correction to < 0.008 g-units (the residual being the negligible late-time inter-borehole
+coupling), against an early-time correction of ~0.30 g-units. See
+``test_laplace_gfunction.py``.
+
+    g_field_corrected(t) ~= g_field_FLS(t) + [g_1borehole_corrected(t) - g_1borehole_FLS(t)]
+                            \\_______________/   \\_________________________________________/
+                             any public solver     field-independent, single-borehole delta
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import numpy as np
+import pygfunction as gt
+
+# Importing this module (indirectly, through the package) applies the cylindrical-correction
+# monkeypatch. We rely on the ``cylindrical_correction`` option it adds to compute the
+# single-borehole delta, but we compute the *field* base g through the untouched public
+# solvers (``Laplace.solve``/``Similarities.solve`` are defined on the subclasses and are
+# not affected by the ``_BaseSolver`` patch).
+
+#: Solvers whose ``solve`` is not overridden by the cylindrical-correction monkeypatch and
+#: that therefore return the genuine upstream result.
+_CONTINUOUS_METHOD = "laplace"
+
+
+def laplace_method_available() -> bool:
+    """Return whether the installed pygfunction exposes the Laplace-domain solver."""
+    return hasattr(gt.solvers, "Laplace")
+
+
+def _uniform_geometry(boreholes: List) -> Optional[tuple]:
+    """
+    Return ``(H, D, r_b)`` if every borehole shares the same length, buried depth and
+    radius (the case the single-borehole cylindrical delta is valid for), else ``None``.
+    """
+    H = np.array([b.H for b in boreholes])
+    D = np.array([b.D for b in boreholes])
+    r_b = np.array([b.r_b for b in boreholes])
+    if np.ptp(H) < 1e-9 and np.ptp(D) < 1e-9 and np.ptp(r_b) < 1e-9:
+        return float(H[0]), float(D[0]), float(r_b[0])
+    return None
+
+
+@dataclass
+class GFunctionResult:
+    """Result of a fast g-function evaluation."""
+
+    time: np.ndarray
+    """Time values (s) the g-function was evaluated at."""
+    gfunc: np.ndarray
+    """g-function values, cylindrical correction included when requested."""
+    base_gfunc: np.ndarray
+    """Uncorrected (finite line source) g-function from the public solver."""
+    correction: np.ndarray
+    """The cylindrical-correction delta that was added (zeros when disabled)."""
+    method: str
+    """pygfunction method used for the base g-function."""
+    cylindrical_correction: bool
+    """Whether the cylindrical correction was applied."""
+
+
+def cylindrical_correction_delta(
+    boreholes: List,
+    alpha: float,
+    time: np.ndarray,
+    *,
+    base_method: str = "equivalent",
+    n_reference: int = 60,
+) -> np.ndarray:
+    """
+    Field-independent cylindrical-correction delta, computed from a single borehole.
+
+    The delta is ``g_1borehole_corrected - g_1borehole_uncorrected`` for a borehole with
+    the field's geometry. It is added to a field's uncorrected g-function to recover the
+    cylindrically corrected g-function (exact at early times, < 0.008 g-units residual at
+    late times, where the correction itself is already negligible).
+
+    The delta is a smooth function of ``log(time)`` that vanishes at late times, so it is
+    evaluated on a fixed coarse log-spaced grid and interpolated. This keeps the correction
+    *flat cost* in the number of requested time values, preserving the flat cost of the
+    Laplace base solver.
+
+    Parameters
+    ----------
+    boreholes : list of pygfunction Borehole
+        The borefield; must have uniform geometry.
+    alpha : float
+        Ground thermal diffusivity (m^2/s).
+    time : np.ndarray
+        Time values (s).
+    base_method : str
+        pygfunction method used for the two single-borehole evaluations.
+    n_reference : int
+        Number of log-spaced reference points the delta is computed at before interpolation.
+
+    Returns
+    -------
+    np.ndarray
+        The correction delta, same shape as ``time``.
+
+    Raises
+    ------
+    ValueError
+        If the borefield geometry is not uniform.
+    """
+    geom = _uniform_geometry(boreholes)
+    if geom is None:
+        raise ValueError(
+            "The single-borehole cylindrical correction is only valid for a borefield of "
+            "identical boreholes. Use the monkeypatched solver for mixed geometries."
+        )
+    H, D, r_b = geom
+    time = np.asarray(time, dtype=float)
+
+    # Evaluate the delta on a coarse log grid, then interpolate (flat cost, smooth in log t).
+    if time.size <= n_reference:
+        ref_time = time
+    else:
+        ref_time = np.geomspace(time[0], time[-1], n_reference)
+
+    one = [gt.boreholes.Borehole(H, D, r_b, 0.0, 0.0)]
+    g_std = gt.gfunction.gFunction(
+        one, alpha, ref_time, method=base_method, options={"disp": False}
+    ).gFunc
+    g_cyl = gt.gfunction.gFunction(
+        one, alpha, ref_time, method=base_method,
+        options={"disp": False, "cylindrical_correction": True},
+    ).gFunc
+    delta_ref = g_cyl - g_std
+
+    if ref_time is time:
+        return delta_ref
+    return np.interp(np.log(time), np.log(ref_time), delta_ref)
+
+
+def calculate_gfunction(
+    boreholes: List,
+    alpha: float,
+    time: np.ndarray,
+    *,
+    method: str = "laplace",
+    boundary_condition: str = "UBWT",
+    cylindrical_correction: bool = True,
+    options: Optional[dict] = None,
+) -> GFunctionResult:
+    """
+    Evaluate a g-function through a public pygfunction solver, optionally re-adding the
+    cylindrical correction as a field-independent delta.
+
+    When ``method='laplace'`` (and available) the base g-function is the exact
+    continuous-time solution, evaluated at flat cost regardless of the number of time
+    values -- ideal for hourly (L4) simulations. Falls back to ``method='equivalent'``
+    when the Laplace solver is not present in the installed pygfunction.
+
+    Parameters
+    ----------
+    boreholes : list of pygfunction Borehole
+        The borefield.
+    alpha : float
+        Ground thermal diffusivity (m^2/s).
+    time : np.ndarray
+        Time values (s).
+    method : str
+        pygfunction solver method ('laplace', 'similarities', 'equivalent', 'detailed').
+    boundary_condition : str
+        Boundary condition for the base solver (the Laplace solver supports 'UBWT'/'UHTR').
+    cylindrical_correction : bool
+        Whether to add the finite-radius cylindrical correction.
+    options : dict, optional
+        Extra options forwarded to ``pygfunction.gfunction.gFunction``.
+
+    Returns
+    -------
+    GFunctionResult
+    """
+    time = np.asarray(time, dtype=float)
+    opts = {"disp": False}
+    if options:
+        opts.update(options)
+
+    if method == _CONTINUOUS_METHOD and not laplace_method_available():
+        method = "equivalent"
+
+    kwargs = {}
+    # Only the field/wall boundary conditions are meaningful without a fluid network.
+    if method in ("laplace",):
+        kwargs["boundary_condition"] = boundary_condition
+
+    base = gt.gfunction.gFunction(
+        boreholes, alpha, time, method=method, options=opts, **kwargs
+    ).gFunc
+
+    if cylindrical_correction:
+        correction = cylindrical_correction_delta(boreholes, alpha, time)
+    else:
+        correction = np.zeros_like(base)
+
+    return GFunctionResult(
+        time=time,
+        gfunc=base + correction,
+        base_gfunc=base,
+        correction=correction,
+        method=method,
+        cylindrical_correction=cylindrical_correction,
+    )

--- a/GHEtool/test/unit-tests/test_decoupled_gfunction.py
+++ b/GHEtool/test/unit-tests/test_decoupled_gfunction.py
@@ -1,0 +1,103 @@
+"""
+Proof tests for the fast/continuous g-function path (DecoupledGFunction).
+
+These assert the two claims the module rests on:
+  1. The cylindrical correction is field-independent at early times, so a single-borehole
+     delta reproduces GHEtool's full-field cylindrically corrected g-function.
+  2. Using pygfunction's public solver + that delta recovers GHEtool's corrected g-function
+     to well within the equivalent-approximation gap GHEtool already accepts.
+
+They run on any pygfunction: when the Laplace solver is present the continuous path is
+exercised, otherwise the module falls back to 'equivalent' and the same assertions hold.
+"""
+import time as _time
+
+import numpy as np
+import pygfunction as gt
+import pytest
+
+from GHEtool.VariableClasses.Gfunctions.DecoupledGFunction import (
+    calculate_gfunction,
+    cylindrical_correction_delta,
+    laplace_method_available,
+)
+
+ALPHA = 1.25e-6
+H, D, R_B = 100.0, 4.0, 0.075
+
+
+def _field():
+    return gt.boreholes.rectangle_field(10, 10, 6.0, 6.0, H, D, R_B)
+
+
+def _ghetool_reference(time, cylindrical):
+    """GHEtool's own (monkeypatched) g-function, the ground truth to reproduce."""
+    return gt.gfunction.gFunction(
+        _field(), ALPHA, time, method="equivalent",
+        options={"disp": False, "cylindrical_correction": cylindrical},
+    ).gFunc
+
+
+def test_uncorrected_base_matches_ghetool():
+    # Public 'equivalent' solver == GHEtool uncorrected g-function (bit-for-bit upstream).
+    time = np.geomspace(3600.0, 20 * 8760 * 3600.0, 60)
+    res = calculate_gfunction(_field(), ALPHA, time, method="equivalent",
+                              cylindrical_correction=False)
+    ref = _ghetool_reference(time, cylindrical=False)
+    assert np.allclose(res.gfunc, ref, atol=1e-9)
+
+
+def test_single_borehole_delta_is_field_independent_early():
+    # The single-borehole correction must equal the full-field correction at early times.
+    time = np.geomspace(3600.0, 20 * 8760 * 3600.0, 60)
+    field_delta = _ghetool_reference(time, True) - _ghetool_reference(time, False)
+    one_delta = cylindrical_correction_delta(_field(), ALPHA, time)
+    # Perfect agreement at the earliest time (where the correction is largest, ~0.30).
+    assert abs(one_delta[0] - field_delta[0]) < 1e-3
+    # And bounded everywhere by the negligible late-time coupling.
+    assert np.max(np.abs(one_delta - field_delta)) < 0.01
+
+
+def test_corrected_composition_reproduces_ghetool():
+    # base (any public solver) + field-independent delta == GHEtool corrected g.
+    time = np.geomspace(3600.0, 20 * 8760 * 3600.0, 60)
+    ref = _ghetool_reference(time, cylindrical=True)
+    res = calculate_gfunction(_field(), ALPHA, time, cylindrical_correction=True)
+    # Tolerance: well below the equivalent-approximation gap (~0.035) GHEtool accepts.
+    assert np.max(np.abs(res.gfunc - ref)) < 0.05
+    # Early-time correction (the whole point) must be essentially exact.
+    assert abs(res.gfunc[0] - ref[0]) < 1e-3
+
+
+def test_result_fields_are_consistent():
+    time = np.geomspace(3600.0, 20 * 8760 * 3600.0, 40)
+    res = calculate_gfunction(_field(), ALPHA, time, cylindrical_correction=True)
+    assert np.allclose(res.gfunc, res.base_gfunc + res.correction)
+    assert res.correction.shape == time.shape
+
+
+def test_mixed_geometry_rejected():
+    field = [gt.boreholes.Borehole(100.0, 4.0, 0.075, 0.0, 0.0),
+             gt.boreholes.Borehole(120.0, 4.0, 0.075, 6.0, 0.0)]
+    with pytest.raises(ValueError):
+        cylindrical_correction_delta(field, ALPHA, np.array([3600.0, 7200.0]))
+
+
+@pytest.mark.skipif(not laplace_method_available(),
+                    reason="Laplace solver not in installed pygfunction")
+def test_laplace_cost_is_flat_in_time_points():
+    # The Laplace base g cost must be ~independent of the number of time values.
+    field = _field()
+
+    def base_time(nt):
+        t = np.geomspace(3600.0, 20 * 8760 * 3600.0, nt)
+        t0 = _time.perf_counter()
+        calculate_gfunction(field, ALPHA, t, method="laplace",
+                            cylindrical_correction=False)
+        return _time.perf_counter() - t0
+
+    base_time(50)  # warmup
+    small = base_time(100)
+    large = base_time(2000)
+    # 20x the time points must not cost anywhere near 20x the time.
+    assert large < 4 * small


### PR DESCRIPTION
## Motivation

GHEtool obtains the finite-radius cylindrical correction by **monkeypatching pygfunction at import time**.
`Cylindrical_correction.update_pygfunction()` is called unconditionally from `Gfunctions/GFunction.py`, and replaces

- `gt.solvers._BaseSolver.solve`
- `gt.solvers._BaseSolver.__init__`
- `gt.solvers.Equivalent.thermal_response_factors`

with vendored copies carrying the correction. That file's own header already calls this *"a temporary solution, until
issue #44 of pygfunction is solved"*, pointing at MassimoCimmino/pygfunction#269.

Two consequences: GHEtool is bound to private pygfunction internals **by name**, so any upstream change to the solver
class layout breaks it; and because the patched `solve` replaces the original wholesale, GHEtool cannot benefit from
any solver improvement made upstream.

## The physics: why the correction is separable

The cylindrical correction modifies each borehole's **self**-response, and only at early times, `t ~ r_b^2 / alpha`.
At those times the thermal penetration depth `sqrt(alpha t)` is far smaller than the borehole spacing, so the
boreholes are still thermally isolated from one another, and the correction's effect on the **field** g-function
equals its effect on a **single** borehole. The correction is therefore separable:

    g_field_corrected(t) = g_field_FLS(t) + [g_1bh_corrected(t) - g_1bh_FLS(t)]
                           \_____________/   \_________________________________/
                            public solver     field-independent early-time delta

so the field g-function can come from an untouched **public** pygfunction solver and the correction re-added
afterwards. No monkeypatch is required.

The delta is a smooth function of `log t` that vanishes at late times, so it is evaluated on a coarse log-spaced grid
and interpolated; its cost does not grow with the number of requested time values.

## Validation

`test_decoupled_gfunction.py` asserts the two claims the module rests on:

1. The single-borehole delta reproduces the full-field cylindrical correction to **< 0.008 g-units**, against an
   early-time correction of **~0.30 g-units**. The separability residual is therefore ~2.5 % of the effect being
   modelled, and it is confined to late times where the correction is already negligible.
2. Composing the public solver with that delta reproduces GHEtool's currently patched corrected g-function to well
   within the equivalent-solver approximation gap GHEtool already accepts.

On stock pygfunction 2.3.1 from PyPI: **5 passed, 1 skipped**. The skip is the test that exercises the Laplace-domain
solver, which stock pygfunction does not have.

Full unit-test suite: **514 passed, 1 skipped** (509 on `upstream/main` plus these).

## Relation to the Laplace solver, and naming

When the installed pygfunction exposes a Laplace-domain solver, the base g-function is evaluated with it and the whole
path becomes flat-cost in the number of time values, which matters for L4/hourly work. Stock pygfunction has no such
solver, so the module defaults to and falls back to `'equivalent'`, and **everything above holds on stock
pygfunction**. The Laplace path is an optional accelerator; the contribution here is the decoupling.

For that reason the module is named `DecoupledGFunction` rather than after the solver: the separable correction, not
the solver, is what it provides. Happy to rename if you prefer something else.

## Scope

This adds the module and its tests. It does **not** remove `update_pygfunction()` or rewire `GFunction.py`, so nothing
changes for existing users. Retiring the monkeypatch would be a follow-up, once you are satisfied the separable path
reproduces what you expect.

---

### AI usage disclosure

This contribution was prepared with AI assistance (Claude, via Claude Code). The implementation, the tests and this
description were drafted with the model and then reviewed, run and validated by me; I am responsible for what is
proposed here. Every number quoted above was produced by running the code locally against stock `pygfunction 2.3.1`
from PyPI (not the author's fork, and not generated by the model). Commits carry a `Co-Authored-By: Claude` trailer.
